### PR TITLE
feat: 画像編集中の次へボタン制御を改善

### DIFF
--- a/CoffeePad/Views/BrewMethod/CreateBrewMethod/CreateBrewMethodIconSelection.swift
+++ b/CoffeePad/Views/BrewMethod/CreateBrewMethod/CreateBrewMethodIconSelection.swift
@@ -7,8 +7,7 @@ struct CreateBrewMethodIconSelection: View {
     let title: String
     let description: String
     @Binding var selectedIconData: Data?
-
-    @StateObject private var photoHandler = PhotoSelectionHandler(cropSize: Constants.cropSize)
+    @ObservedObject var photoHandler: PhotoSelectionHandler
 
     private enum Constants {
         static let cropSize: CGFloat = 280

--- a/CoffeePad/Views/BrewMethod/CreateBrewMethod/CreateBrewMethodIconSelection.swift
+++ b/CoffeePad/Views/BrewMethod/CreateBrewMethod/CreateBrewMethodIconSelection.swift
@@ -53,6 +53,14 @@ struct CreateBrewMethodIconSelection: View {
             }
         }
         .padding(.horizontal, 20)
+        .onChange(of: self.photoHandler.selectedItem) { _, newItem in
+            if newItem != nil {
+                self.photoHandler.startImageSelection()
+                DispatchQueue.main.async {
+                    self.photoHandler.objectWillChange.send()
+                }
+            }
+        }
         .enableInjection()
     }
 

--- a/CoffeePad/Views/BrewMethod/CreateBrewMethod/CreateBrewMethodStepContent.swift
+++ b/CoffeePad/Views/BrewMethod/CreateBrewMethod/CreateBrewMethodStepContent.swift
@@ -18,6 +18,7 @@ struct CreateBrewMethodStepContent: View {
     @Binding var brewSteps: [BrewStep]
     @Binding var comment: String
     let grindOptions: [String]
+    let photoHandler: PhotoSelectionHandler
 
     var body: some View {
         self.stepContent
@@ -78,7 +79,8 @@ struct CreateBrewMethodStepContent: View {
             CreateBrewMethodIconSelection(
                 title: "メソッドアイコンを選択",
                 description: "メソッドを表す写真を選んでください",
-                selectedIconData: self.$selectedIconData
+                selectedIconData: self.$selectedIconData,
+                photoHandler: self.photoHandler
             )
         case .confirm:
             BrewMethodConfirmView(

--- a/CoffeePad/Views/BrewMethod/CreateBrewMethod/PhotoSelectionHandler.swift
+++ b/CoffeePad/Views/BrewMethod/CreateBrewMethod/PhotoSelectionHandler.swift
@@ -10,6 +10,7 @@ class PhotoSelectionHandler: ObservableObject {
     @Published var lastOffset = CGSize.zero
     @Published var scale: CGFloat = 1.0
     @Published var lastScale: CGFloat = 1.0
+    @Published var isCropping = false
 
     private let cropSize: CGFloat
 
@@ -43,6 +44,7 @@ class PhotoSelectionHandler: ObservableObject {
         let fixedImage = self.fixImageOrientation(image)
         self.selectedUIImage = fixedImage
         self.resetCropParameters()
+        self.isCropping = true
     }
 
     /// クロップパラメータをリセット
@@ -185,6 +187,7 @@ class PhotoSelectionHandler: ObservableObject {
     func completeCropping() -> Data? {
         let imageData = self.cropAndSaveImage()
         self.selectedUIImage = nil
+        self.isCropping = false
         return imageData
     }
 }

--- a/CoffeePad/Views/BrewMethod/CreateBrewMethod/PhotoSelectionHandler.swift
+++ b/CoffeePad/Views/BrewMethod/CreateBrewMethod/PhotoSelectionHandler.swift
@@ -11,11 +11,19 @@ class PhotoSelectionHandler: ObservableObject {
     @Published var scale: CGFloat = 1.0
     @Published var lastScale: CGFloat = 1.0
     @Published var isCropping = false
+    @Published var isEditingImage = false
 
     private let cropSize: CGFloat
 
     init(cropSize: CGFloat) {
         self.cropSize = cropSize
+    }
+
+    /// 画像選択開始時の状態設定
+    func startImageSelection() {
+        DispatchQueue.main.async {
+            self.isEditingImage = true
+        }
     }
 
     /// 画像選択処理
@@ -36,6 +44,8 @@ class PhotoSelectionHandler: ObservableObject {
             }
         } catch {
             print("画像の読み込みに失敗しました: \(error)")
+            // エラー時は編集状態をリセット
+            self.isEditingImage = false
         }
     }
 
@@ -188,6 +198,9 @@ class PhotoSelectionHandler: ObservableObject {
         let imageData = self.cropAndSaveImage()
         self.selectedUIImage = nil
         self.isCropping = false
+        DispatchQueue.main.async {
+            self.isEditingImage = false
+        }
         return imageData
     }
 }

--- a/CoffeePad/Views/BrewMethod/CreateBrewMethodView.swift
+++ b/CoffeePad/Views/BrewMethod/CreateBrewMethodView.swift
@@ -15,6 +15,7 @@ struct CreateBrewMethodView: View {
     @State private var brewSteps: [BrewStep] = []
     @State private var comment: String = ""
     @State private var selectedIconData: Data?
+    @State private var photoHandler = PhotoSelectionHandler(cropSize: 280)
 
     private let editingMethod: BrewMethod?
     private let isEditMode: Bool
@@ -41,7 +42,7 @@ struct CreateBrewMethodView: View {
         case .coffeeVolume:
             Int(self.coffeeVolume) != nil
         case .iconSelection:
-            true
+            !self.photoHandler.isCropping
         default:
             true
         }
@@ -95,7 +96,8 @@ struct CreateBrewMethodView: View {
             coffeeVolume: self.$coffeeVolume,
             brewSteps: self.$brewSteps,
             comment: self.$comment,
-            grindOptions: self.grindOptions
+            grindOptions: self.grindOptions,
+            photoHandler: self.photoHandler
         )
         .animation(.easeInOut, value: self.currentStep)
     }

--- a/CoffeePad/Views/BrewMethod/CreateBrewMethodView.swift
+++ b/CoffeePad/Views/BrewMethod/CreateBrewMethodView.swift
@@ -15,7 +15,7 @@ struct CreateBrewMethodView: View {
     @State private var brewSteps: [BrewStep] = []
     @State private var comment: String = ""
     @State private var selectedIconData: Data?
-    @State private var photoHandler = PhotoSelectionHandler(cropSize: 280)
+    @StateObject private var photoHandler = PhotoSelectionHandler(cropSize: 280)
 
     private let editingMethod: BrewMethod?
     private let isEditMode: Bool
@@ -28,7 +28,7 @@ struct CreateBrewMethodView: View {
     }
 
     var canProceedToNextStep: Bool {
-        switch self.currentStep {
+        let result: Bool = switch self.currentStep {
         case .methodName:
             !self.methodName.trimmingCharacters(in: .whitespaces).isEmpty
         case .grindSize:
@@ -42,10 +42,11 @@ struct CreateBrewMethodView: View {
         case .coffeeVolume:
             Int(self.coffeeVolume) != nil
         case .iconSelection:
-            !self.photoHandler.isCropping
+            !self.photoHandler.isEditingImage
         default:
             true
         }
+        return result
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- 画像選択時の次へボタン制御ロジックを完全に修正
- フォトピッカー選択と同時に次へボタンを無効化
- @StateObjectによる適切な状態管理でSwiftUIの更新を確実に実行

## Changes
- PhotoSelectionHandlerを@StateObjectに変更
- isEditingImageフラグによる画像編集状態の管理
- フォトピッカー選択開始時の即座な次へボタン無効化
- メインスレッドでの確実なUI更新

## Test plan
- [x] 画像未選択時: 次へボタン有効
- [x] フォトピッカー選択瞬間: 次へボタン無効化（薄く表示）
- [x] 画像クロップ中: 次へボタン無効
- [x] クロップ完了後: 次へボタン有効

🤖 Generated with [Claude Code](https://claude.ai/code)